### PR TITLE
chore: improve status message

### DIFF
--- a/spendingbot/frontend/SpendingBotApp/App.js
+++ b/spendingbot/frontend/SpendingBotApp/App.js
@@ -48,7 +48,7 @@ export default function App() {
     const exchangeAndFetch = useCallback(async (publicToken) => {
         try {
             setBusy(true);
-            setStatus('Exchanging public_token…');
+            setStatus('Exchanging public token…');
 
             // Our backend expects JSON body for exchange
             const ex = await fetch(`${BASE_URL}/plaid/exchange_public_token`, {


### PR DESCRIPTION
## Summary
- improve Plaid token exchange status message

## Testing
- `npm test` *(fails: Identifier 'NativeModules' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3927e05c8331b1b0a607d444a8ff