### PR TITLE
Fix Fernet key initialization to avoid TypeError

### DIFF
--- a/spendingbot/backend/app/crypto.py
+++ b/spendingbot/backend/app/crypto.py
@@ -1,10 +1,15 @@
-import os, base64
+import os
 from cryptography.fernet import Fernet
 
 _key = os.getenv("ENCRYPTION_KEY")
 if not _key:
     raise RuntimeError("ENCRYPTION_KEY missing in .env")
-fernet = Fernet(_key.encode() if not _key.startswith("gAAAA") else _key)
+# Fernet keys are URL-safe base64-encoded strings. The cryptography
+# library expects the key as bytes, so always encode the environment
+# variable rather than attempting to detect its format. Previously the
+# code skipped encoding when the key began with "gAAAA", which could
+# result in a `TypeError` if a valid key happened to have that prefix.
+fernet = Fernet(_key.encode())
 
 def encrypt(text: str) -> str:
     return fernet.encrypt(text.encode()).decode()

--- a/spendingbot/backend/tests/test_crypto.py
+++ b/spendingbot/backend/tests/test_crypto.py
@@ -1,0 +1,18 @@
+import importlib
+import os
+import sys
+
+# Ensure the backend app package is importable
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if BASE_DIR not in sys.path:
+    sys.path.append(BASE_DIR)
+
+
+def test_encrypt_decrypt_with_gAAAA_key(monkeypatch):
+    key = "gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    monkeypatch.setenv("ENCRYPTION_KEY", key)
+    # Reload the crypto module so it picks up the new env var
+    crypto = importlib.import_module("app.crypto")
+    importlib.reload(crypto)
+    token = crypto.encrypt("secret")
+    assert crypto.decrypt(token) == "secret"


### PR DESCRIPTION
## Summary
- Always encode `ENCRYPTION_KEY` when creating the Fernet instance
- Add regression test for keys starting with `gAAAA`

## Testing
- `cd spendingbot/backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae382fc4b88331bfa6832adbe494da