### PR TITLE
Add header text assertion in App test

### DIFF
--- a/spendingbot/frontend/SpendingBotApp/App.js
+++ b/spendingbot/frontend/SpendingBotApp/App.js
@@ -3,7 +3,6 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { SafeAreaView, View, Text, Button, FlatList, ActivityIndicator, StyleSheet, Alert } from 'react-native';
 import { PlaidLink } from 'react-native-plaid-link-sdk';
 import { NativeModules, Platform } from 'react-native';
-import { NativeModules } from 'react-native';
 console.log('PlaidLink typeof:', typeof PlaidLink);
 console.log('RNLinksdk present?', !!NativeModules.RNLinksdk);
 

--- a/spendingbot/frontend/SpendingBotApp/__tests__/App.test.tsx
+++ b/spendingbot/frontend/SpendingBotApp/__tests__/App.test.tsx
@@ -3,11 +3,14 @@
  */
 
 import React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 import App from '../App';
 
-test('renders correctly', async () => {
-  await ReactTestRenderer.act(() => {
-    ReactTestRenderer.create(<App />);
-  });
+jest.mock('react-native-plaid-link-sdk', () => ({
+  PlaidLink: () => null,
+}));
+
+test('renders SpendingBot header', () => {
+  const { getByText } = render(<App />);
+  expect(getByText('SpendingBot')).toBeTruthy();
 });


### PR DESCRIPTION
## Summary
- use @testing-library/react-native to render App and assert SpendingBot header text
- remove duplicate NativeModules import in App.js causing parse errors

## Testing
- `cd spendingbot/frontend/SpendingBotApp && npm test --silent | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ae39335ffc83318782cee052f2ce5f