### PR TITLE
docs: fix dev setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Local dev:
-1) cd spendingbot/frontend
+1) cd spendingbot/frontend/SpendingBotApp
 2) npm install
-3) npm run dev
+3) npm start
 
 Notes:
 - Do not commit node_modules (handled by .gitignore)


### PR DESCRIPTION
## Summary
- use `npm start` for local dev and point to the SpendingBotApp directory

## Testing
- `npm test` *(fails: Identifier 'NativeModules' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68ae392d552c833192efa6933043a4bc